### PR TITLE
Add AbilityCondition, MovesCondition

### DIFF
--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
@@ -17,8 +17,10 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.api.DropContext
 import us.timinc.mc.cobblemon.droploottables.api.Dropper
 import us.timinc.mc.cobblemon.droploottables.api.DropperType
+import us.timinc.mc.cobblemon.droploottables.condition.AbilityCondition
 import us.timinc.mc.cobblemon.droploottables.condition.CaughtBallCondition
 import us.timinc.mc.cobblemon.droploottables.condition.KnowledgeLevelCondition
+import us.timinc.mc.cobblemon.droploottables.condition.MovesCondition
 import us.timinc.mc.cobblemon.droploottables.condition.PokemonMatcherCondition
 import us.timinc.mc.cobblemon.droploottables.condition.TeamMatcherCondition
 import us.timinc.mc.cobblemon.droploottables.data.DropperDataManager
@@ -100,6 +102,8 @@ object DropLootTables : AbstractMod<DropLootTables.DropLootTablesConfig>(MOD_ID,
             val KNOWLEDGE_LEVEL = modResource("knowledge_level")
             val POKEMON_MATCHER = modResource("pokemon_matcher")
             val TEAM_MATCHER = modResource("team_matcher")
+            val ABILITY = modResource("ability")
+            val MOVES = modResource("moves")
         }
 
         object LootParamKeys {
@@ -156,6 +160,10 @@ object DropLootTables : AbstractMod<DropLootTables.DropLootTablesConfig>(MOD_ID,
             register(DataKeys.DropConditionKeys.POKEMON_MATCHER, PokemonMatcherCondition.CODEC)
         val TEAM_MATCHER_CONDITION =
             register(DataKeys.DropConditionKeys.TEAM_MATCHER, TeamMatcherCondition.CODEC)
+        val ABILITY_CONDITION =
+            register(DataKeys.DropConditionKeys.ABILITY, AbilityCondition.CODEC)
+        val MOVES_CONDITION =
+            register(DataKeys.DropConditionKeys.MOVES, MovesCondition.CODEC)
 
         fun <T : LootItemCondition> register(id: ResourceLocation, codec: MapCodec<T>): LootItemConditionType {
             return Registry.register(BuiltInRegistries.LOOT_CONDITION_TYPE, id, LootItemConditionType(codec))

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/AbilityCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/AbilityCondition.kt
@@ -1,0 +1,37 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class AbilityCondition (
+    val targetPokemon: ResourceLocation = DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON,
+    val abilities: List<String>,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<AbilityCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                ResourceLocation.CODEC.optionalFieldOf(
+                    "target_pokemon",
+                    DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+                ).forGetter(AbilityCondition::targetPokemon),
+                Codec.STRING.listOf().fieldOf("abilities")
+                    .forGetter(AbilityCondition::abilities)
+            ).apply(instance, ::AbilityCondition)
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.ABILITY_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        return abilities.contains(pokemon.ability.name)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/MovesCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/MovesCondition.kt
@@ -1,0 +1,41 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class MovesCondition (
+    val targetPokemon: ResourceLocation = DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON,
+    val moves: List<String>,
+    val all: Boolean = false
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                ResourceLocation.CODEC.optionalFieldOf(
+                    "target_pokemon",
+                    DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+                ).forGetter(MovesCondition::targetPokemon),
+                Codec.STRING.listOf().fieldOf("moves")
+                    .forGetter(MovesCondition::moves),
+                Codec.BOOL.fieldOf("all").orElse(false)
+                    .forGetter(MovesCondition::all),
+            ).apply(instance, ::MovesCondition)
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val pokemonMoveNames = pokemon.moveSet.map { it.name }
+        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+    }
+}


### PR DESCRIPTION
- Added AbilityCondition and MovesCondition for compatibility with previous version tables.

Example:

```json
"conditions": [
    {
      "condition": "droploottables:ability",
      "abilities": [
        "unaware"
      ]
    },
    {
      "condition": "droploottables:moves",
      "moves": [
        "rollout"
      ]
    },
  ]
 ```