### PR TITLE
Add Remaining Old Conditions

### DIFF
--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
@@ -18,11 +18,35 @@ import us.timinc.mc.cobblemon.droploottables.api.DropContext
 import us.timinc.mc.cobblemon.droploottables.api.Dropper
 import us.timinc.mc.cobblemon.droploottables.api.DropperType
 import us.timinc.mc.cobblemon.droploottables.condition.AbilityCondition
+import us.timinc.mc.cobblemon.droploottables.condition.AspectsCondition
 import us.timinc.mc.cobblemon.droploottables.condition.CaughtBallCondition
+import us.timinc.mc.cobblemon.droploottables.condition.DynamaxLevelCondition
+import us.timinc.mc.cobblemon.droploottables.condition.EggGroupCondition
+import us.timinc.mc.cobblemon.droploottables.condition.ElementalTypeCondition
+import us.timinc.mc.cobblemon.droploottables.condition.EvCondition
+import us.timinc.mc.cobblemon.droploottables.condition.FriendshipLevelCondition
+import us.timinc.mc.cobblemon.droploottables.condition.GenderCondition
+import us.timinc.mc.cobblemon.droploottables.condition.GmaxCondition
+import us.timinc.mc.cobblemon.droploottables.condition.HeldItemCondition
+import us.timinc.mc.cobblemon.droploottables.condition.HiddenAbilityCondition
+import us.timinc.mc.cobblemon.droploottables.condition.IvCondition
 import us.timinc.mc.cobblemon.droploottables.condition.KnowledgeLevelCondition
+import us.timinc.mc.cobblemon.droploottables.condition.LabelCondition
+import us.timinc.mc.cobblemon.droploottables.condition.LevelCondition
+import us.timinc.mc.cobblemon.droploottables.condition.MoveTypesCondition
 import us.timinc.mc.cobblemon.droploottables.condition.MovesCondition
+import us.timinc.mc.cobblemon.droploottables.condition.NatureCondition
+import us.timinc.mc.cobblemon.droploottables.condition.NicknameCondition
+import us.timinc.mc.cobblemon.droploottables.condition.OriginalTrainerCondition
+import us.timinc.mc.cobblemon.droploottables.condition.PersistentDataCondition
+import us.timinc.mc.cobblemon.droploottables.condition.PersistentDataRangeCondition
 import us.timinc.mc.cobblemon.droploottables.condition.PokemonMatcherCondition
+import us.timinc.mc.cobblemon.droploottables.condition.PropertiesCondition
+import us.timinc.mc.cobblemon.droploottables.condition.ShinyCondition
+import us.timinc.mc.cobblemon.droploottables.condition.StatusCondition
 import us.timinc.mc.cobblemon.droploottables.condition.TeamMatcherCondition
+import us.timinc.mc.cobblemon.droploottables.condition.TeraTypeCondition
+import us.timinc.mc.cobblemon.droploottables.condition.TradeableCondition
 import us.timinc.mc.cobblemon.droploottables.data.DropperDataManager
 import us.timinc.mc.cobblemon.droploottables.dropper.CapturedDropper
 import us.timinc.mc.cobblemon.droploottables.dropper.DefeatedDropper
@@ -98,12 +122,36 @@ object DropLootTables : AbstractMod<DropLootTables.DropLootTablesConfig>(MOD_ID,
         }
 
         object DropConditionKeys {
-            val CAUGHT_BALL = modResource("caught_ball")
-            val KNOWLEDGE_LEVEL = modResource("knowledge_level")
-            val POKEMON_MATCHER = modResource("pokemon_matcher")
-            val TEAM_MATCHER = modResource("team_matcher")
             val ABILITY = modResource("ability")
+            val ASPECTS = modResource("aspects")
+            val CAUGHT_BALL = modResource("caught_ball")
+            val DYNAMAX_LEVEL = modResource("dynamax_level")
+            val EGG_GROUPS = modResource("egg_group")
+            val ELEMENTAL_TYPE = modResource("type")
+            val EV = modResource("ev")
+            val FRIENDSHIP = modResource("friendship")
+            val GENDER = modResource("gender")
+            val GMAX = modResource("gmax")
+            val HELD_ITEM = modResource("held_item")
+            val HIDDEN_ABILITY = modResource("hidden_ability")
+            val IV = modResource("iv")
+            val KNOWLEDGE_LEVEL = modResource("knowledge_level")
+            val LABEL = modResource("label")
+            val LEVEL = modResource("level")
             val MOVES = modResource("moves")
+            val MOVE_TYPES = modResource("move_types")
+            val NATURE = modResource("nature")
+            val NICKNAME = modResource("nickname")
+            val ORIGINAL_TRAINER = modResource("original_trainer")
+            val PERSISTENT_DATA = modResource("persistent_data")
+            val PERSISTENT_DATA_RANGE = modResource("persistent_data_range")
+            val POKEMON_MATCHER = modResource("pokemon_matcher")
+            val PROPERTIES = modResource("properties")
+            val SHINY = modResource("shiny")
+            val STATUS = modResource("status")
+            val TEAM_MATCHER = modResource("team_matcher")
+            val TERA_TYPE = modResource("tera_type")
+            val TRADEABLE = modResource("tradeable")
         }
 
         object LootParamKeys {
@@ -153,17 +201,66 @@ object DropLootTables : AbstractMod<DropLootTables.DropLootTablesConfig>(MOD_ID,
     }
 
     object LootItemConditionTypes {
-        val CAUGHT_BALL_CONDITION = register(DataKeys.DropConditionKeys.CAUGHT_BALL, CaughtBallCondition.CODEC)
-        val KNOWLEDGE_LEVEL_CONDITION =
-            register(DataKeys.DropConditionKeys.KNOWLEDGE_LEVEL, KnowledgeLevelCondition.CODEC)
-        val POKEMON_MATCHER_CONDITION =
-            register(DataKeys.DropConditionKeys.POKEMON_MATCHER, PokemonMatcherCondition.CODEC)
-        val TEAM_MATCHER_CONDITION =
-            register(DataKeys.DropConditionKeys.TEAM_MATCHER, TeamMatcherCondition.CODEC)
         val ABILITY_CONDITION =
             register(DataKeys.DropConditionKeys.ABILITY, AbilityCondition.CODEC)
+        val ASPECTS_CONDITION =
+            register(DataKeys.DropConditionKeys.ASPECTS, AspectsCondition.CODEC)
+        val CAUGHT_BALL_CONDITION =
+            register(DataKeys.DropConditionKeys.CAUGHT_BALL, CaughtBallCondition.CODEC)
+        val DYNAMAX_LEVEL_CONDITION =
+            register(DataKeys.DropConditionKeys.DYNAMAX_LEVEL, DynamaxLevelCondition.CODEC)
+        val EGG_GROUP_CONDITION =
+            register(DataKeys.DropConditionKeys.EGG_GROUPS, EggGroupCondition.CODEC)
+        val ELEMENTAL_TYPES_CONDITION =
+            register(DataKeys.DropConditionKeys.ELEMENTAL_TYPE, ElementalTypeCondition.CODEC)
+        val EV_CONDITION =
+            register(DataKeys.DropConditionKeys.EV, EvCondition.CODEC)
+        val FRIENDSHIP_CONDITION =
+            register(DataKeys.DropConditionKeys.FRIENDSHIP, FriendshipLevelCondition.CODEC)
+        val GENDER_CONDITION =
+            register(DataKeys.DropConditionKeys.GENDER, GenderCondition.CODEC)
+        val GMAX_CONDITION =
+            register(DataKeys.DropConditionKeys.GMAX, GmaxCondition.CODEC)
+        val HELD_ITEM_CONDITION =
+            register(DataKeys.DropConditionKeys.HELD_ITEM, HeldItemCondition.CODEC)
+        val HIDDEN_ABILITY_CONDITION =
+            register(DataKeys.DropConditionKeys.HIDDEN_ABILITY, HiddenAbilityCondition.CODEC)
+        val IV_CONDITION =
+            register(DataKeys.DropConditionKeys.IV, IvCondition.CODEC)
+        val KNOWLEDGE_LEVEL_CONDITION =
+            register(DataKeys.DropConditionKeys.KNOWLEDGE_LEVEL, KnowledgeLevelCondition.CODEC)
+        val LABEL_CONDITION =
+            register(DataKeys.DropConditionKeys.LABEL, LabelCondition.CODEC)
+        val LEVEL_CONDITION =
+            register(DataKeys.DropConditionKeys.LEVEL, LevelCondition.CODEC)
         val MOVES_CONDITION =
             register(DataKeys.DropConditionKeys.MOVES, MovesCondition.CODEC)
+        val MOVE_TYPES_CONDITION =
+            register(DataKeys.DropConditionKeys.MOVE_TYPES, MoveTypesCondition.CODEC)
+        val NATURE_CONDITION =
+            register(DataKeys.DropConditionKeys.NATURE, NatureCondition.CODEC)
+        val NICKNAME_CONDITION =
+            register(DataKeys.DropConditionKeys.NICKNAME, NicknameCondition.CODEC)
+        val ORIGINAL_TRAINER_CONDITION =
+            register(DataKeys.DropConditionKeys.ORIGINAL_TRAINER, OriginalTrainerCondition.CODEC)
+        val PERSISTENT_DATA_CONDITION =
+            register(DataKeys.DropConditionKeys.PERSISTENT_DATA, PersistentDataCondition.CODEC)
+        val PERSISTENT_DATA_RANGE_CONDITION =
+            register(DataKeys.DropConditionKeys.PERSISTENT_DATA_RANGE, PersistentDataRangeCondition.CODEC)
+        val POKEMON_MATCHER_CONDITION =
+            register(DataKeys.DropConditionKeys.POKEMON_MATCHER, PokemonMatcherCondition.CODEC)
+        val PROPERTIES_CONDITION =
+            register(DataKeys.DropConditionKeys.PROPERTIES, PropertiesCondition.CODEC)
+        val SHINY_CONDITION =
+            register(DataKeys.DropConditionKeys.SHINY, ShinyCondition.CODEC)
+        val STATUS_CONDITION =
+            register(DataKeys.DropConditionKeys.STATUS, StatusCondition.CODEC)
+        val TEAM_MATCHER_CONDITION =
+            register(DataKeys.DropConditionKeys.TEAM_MATCHER, TeamMatcherCondition.CODEC)
+        val TERA_TYPE_CONDITION =
+            register(DataKeys.DropConditionKeys.TERA_TYPE, TeraTypeCondition.CODEC)
+        val TRADEABLE_CONDITION =
+            register(DataKeys.DropConditionKeys.TRADEABLE, TradeableCondition.CODEC)
 
         fun <T : LootItemCondition> register(id: ResourceLocation, codec: MapCodec<T>): LootItemConditionType {
             return Registry.register(BuiltInRegistries.LOOT_CONDITION_TYPE, id, LootItemConditionType(codec))

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/Util.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/Util.kt
@@ -1,0 +1,21 @@
+package us.timinc.mc.cobblemon.droploottables
+
+import com.cobblemon.mod.common.util.math.FloatRange
+
+fun toFloatRange(str: String): FloatRange {
+    val (start, end) = str.split("..")
+
+    return try {
+        val actualStart = when (start.lowercase()) {
+            "min" -> Float.MIN_VALUE
+            else -> start.toFloat()
+        }
+        val actualEnd = when (end.lowercase()) {
+            "max" -> Float.MAX_VALUE
+            else -> end.toFloat()
+        }
+        FloatRange(actualStart, actualEnd)
+    } catch (e: NumberFormatException) {
+        throw IllegalArgumentException("'$start' and/or '$end' is/are not Floats", e)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/AspectsCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/AspectsCondition.kt
@@ -12,29 +12,28 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class AspectsCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val aspects: List<String>,
+    val all: Boolean = false,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<AspectsCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
+                    .forGetter(AspectsCondition::targetPokemon),
+                Codec.STRING.listOf().fieldOf("aspects")
+                    .forGetter(AspectsCondition::aspects),
                 Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(AspectsCondition::all),
+            ).apply(instance, ::AspectsCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.ASPECTS_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        return if (all) aspects.all(pokemon.aspects::contains) else aspects.any(pokemon.aspects::contains)
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/DynamaxLevelCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/DynamaxLevelCondition.kt
@@ -1,0 +1,47 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import com.google.gson.JsonParser
+import com.mojang.serialization.JsonOps
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import us.timinc.mc.cobblemon.timcore.codec.INT_RANGE_CODEC
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class DynamaxLevelCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val range: IntRange,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<DynamaxLevelCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.fieldOf("range")
+                    .forGetter { it.range.toString() }
+            ).apply(instance) { pokemon, level ->
+                DynamaxLevelCondition (
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    INT_RANGE_CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(level)).getOrThrow()
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.DYNAMAX_LEVEL_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val pokemonLevel = pokemon.dmaxLevel
+        return range.contains(pokemonLevel)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/EggGroupCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/EggGroupCondition.kt
@@ -1,0 +1,48 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.api.pokemon.egg.EggGroup
+import com.cobblemon.mod.common.util.codec.CodecUtils
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class EggGroupCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val eggGroups: List<EggGroup>,
+    val all: Boolean = false,
+) : LootItemCondition {
+    companion object {
+        // TODO: Remove if/when Cobblemon adds one.
+        private val EGG_GROUP_BY_STRING_CODEC: Codec<EggGroup> = CodecUtils.createByStringCodec(
+            EggGroup::fromIdentifier,
+            EggGroup::name
+        ) { id -> "No EggGroup for ID $id" }
+
+        val CODEC: MapCodec<EggGroupCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
+                    .forGetter(EggGroupCondition::targetPokemon),
+                EGG_GROUP_BY_STRING_CODEC.listOf().fieldOf("egg_groups")
+                    .forGetter(EggGroupCondition::eggGroups),
+                Codec.BOOL.fieldOf("all").orElse(false)
+                    .forGetter(EggGroupCondition::all)
+            ).apply(instance, ::EggGroupCondition)
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.EGG_GROUP_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val pokemonEggGroups = pokemon.form.eggGroups
+        return if (all) eggGroups.all(pokemonEggGroups::contains) else eggGroups.any(pokemonEggGroups::contains)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/ElementalTypeCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/ElementalTypeCondition.kt
@@ -1,40 +1,41 @@
 package us.timinc.mc.cobblemon.droploottables.condition
 
+import com.cobblemon.mod.common.api.types.ElementalType
 import com.mojang.serialization.Codec
 import com.mojang.serialization.MapCodec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class ElementalTypeCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val elements: List<ElementalType>,
+    val all: Boolean = false,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<ElementalTypeCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
+                    .forGetter(ElementalTypeCondition::targetPokemon),
+                ElementalType.BY_STRING_CODEC.listOf().fieldOf("elements")
+                    .forGetter(ElementalTypeCondition::elements),
                 Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(ElementalTypeCondition::all)
+            ).apply(instance, ::ElementalTypeCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.ELEMENTAL_TYPES_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        val pokemonTypes = pokemon.types
+        return if (all) elements.all(pokemonTypes::contains) else elements.any(pokemonTypes::contains)
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/EvCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/EvCondition.kt
@@ -1,0 +1,52 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.api.pokemon.stats.Stats
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.google.gson.JsonParser
+import com.mojang.serialization.Codec
+import com.mojang.serialization.JsonOps
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import us.timinc.mc.cobblemon.timcore.codec.INT_RANGE_CODEC
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class EvCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val range: IntRange,
+    val stat: String,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<EvCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.fieldOf("range")
+                    .forGetter { it.range.toString() },
+                Codec.STRING.fieldOf("stat")
+                    .forGetter(EvCondition::stat)
+            ).apply(instance) { pokemon, range, stat ->
+                EvCondition(
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    INT_RANGE_CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(range)).getOrThrow(),
+                    stat
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.EV_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val pokemonEv = pokemon.evs[Stats.getStat(stat)]
+        return range.contains(pokemonEv)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/FriendshipLevelCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/FriendshipLevelCondition.kt
@@ -1,0 +1,47 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.google.gson.JsonParser
+import com.mojang.serialization.Codec
+import com.mojang.serialization.JsonOps
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.timcore.codec.INT_RANGE_CODEC
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class FriendshipLevelCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val range: IntRange,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<FriendshipLevelCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.fieldOf("range")
+                    .forGetter { it.range.toString() }
+            ).apply(instance) { pokemon, range ->
+                FriendshipLevelCondition(
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    INT_RANGE_CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(range)).getOrThrow()
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.FRIENDSHIP_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val pokemonFriendship = pokemon.friendship
+        return range.contains(pokemonFriendship)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/GenderCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/GenderCondition.kt
@@ -12,29 +12,26 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class GenderCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val genders: List<String>,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<GenderCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(GenderCondition::targetPokemon),
+                Codec.STRING.listOf().fieldOf("genders")
+                    .forGetter(GenderCondition::genders)
+            ).apply(instance, ::GenderCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.GENDER_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        val pokemonGender = pokemon.gender.name
+        return genders.contains(pokemonGender.lowercase())
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/GmaxCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/GmaxCondition.kt
@@ -12,29 +12,25 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class GmaxCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val value: Boolean = true,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<GmaxCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(GmaxCondition::targetPokemon),
+                Codec.BOOL.fieldOf("value").orElse(true)
+                    .forGetter(GmaxCondition::value)
+            ).apply(instance, ::GmaxCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.GMAX_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        return pokemon.gmaxFactor == value
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/HeldItemCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/HeldItemCondition.kt
@@ -1,0 +1,52 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.mojang.brigadier.StringReader
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.commands.arguments.item.ItemParser
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class HeldItemCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val item: String,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<HeldItemCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
+                    .forGetter(HeldItemCondition::targetPokemon),
+                Codec.STRING.fieldOf("item")
+                    .forGetter(HeldItemCondition::item)
+            ).apply(instance, ::HeldItemCondition)
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.HELD_ITEM_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+
+        val heldItem = pokemon.heldItem()
+        if (heldItem.isEmpty) return false
+
+        val parser = ItemParser(ctx.level.server.registryAccess())
+        val result = parser.parse(StringReader(item))
+
+        if (!heldItem.`is`(result.item)) return false
+
+        for (entry in result.components.entrySet()) {
+            val targetPropValue = heldItem.get(entry.key)
+            if (targetPropValue != entry.value.get()) return false
+        }
+
+        return true
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/HiddenAbilityCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/HiddenAbilityCondition.kt
@@ -6,35 +6,36 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import com.cobblemon.mod.common.api.Priority
+import com.cobblemon.mod.common.pokemon.Pokemon
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class HiddenAbilityCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val value: Boolean = true,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<HiddenAbilityCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(HiddenAbilityCondition::targetPokemon),
+                Codec.BOOL.fieldOf("value").orElse(true)
+                    .forGetter(HiddenAbilityCondition::value)
+            ).apply(instance, ::HiddenAbilityCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.HIDDEN_ABILITY_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        return pokemon.hasHiddenAbility() == value
     }
+
+    private fun Pokemon.hasHiddenAbility(): Boolean =
+        form.abilities.filter { it.priority == Priority.LOW }.map { it.template.name }.contains(ability.name)
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/IvCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/IvCondition.kt
@@ -1,0 +1,52 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.api.pokemon.stats.Stats
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import com.google.gson.JsonParser
+import com.mojang.serialization.JsonOps
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import us.timinc.mc.cobblemon.timcore.codec.INT_RANGE_CODEC
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class IvCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val range: IntRange,
+    val stat: String,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<IvCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.fieldOf("range")
+                    .forGetter { it.range.toString() },
+                Codec.STRING.fieldOf("stat")
+                    .forGetter(IvCondition::stat)
+            ).apply(instance) { pokemon, range, stat ->
+                IvCondition(
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    INT_RANGE_CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(range)).getOrThrow(),
+                    stat
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.IV_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val pokemonEv = pokemon.ivs[Stats.getStat(stat)]
+        return range.contains(pokemonEv)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/LabelCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/LabelCondition.kt
@@ -6,35 +6,35 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class LabelCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val labels: List<String>,
+    val all: Boolean = false,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<LabelCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
+                    .forGetter(LabelCondition::targetPokemon),
+                Codec.STRING.listOf().fieldOf("labels")
+                    .forGetter(LabelCondition::labels),
                 Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(LabelCondition::all)
+            ).apply(instance, ::LabelCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.LABEL_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        val pokemonLabels = pokemon.form.labels
+        return if (all) labels.all(pokemonLabels::contains) else labels.any(pokemonLabels::contains)
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/LevelCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/LevelCondition.kt
@@ -1,0 +1,46 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.google.gson.JsonParser
+import com.mojang.serialization.Codec
+import com.mojang.serialization.JsonOps
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import us.timinc.mc.cobblemon.timcore.codec.INT_RANGE_CODEC
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class LevelCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val range: IntRange,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<LevelCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.fieldOf("range").forGetter { it.range.toString() }
+            ).apply(instance) { pokemon, range ->
+                LevelCondition(
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    INT_RANGE_CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(range)).getOrThrow()
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.LEVEL_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val pokemonLevel = pokemon.level
+        return range.contains(pokemonLevel)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/MoveTypesCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/MoveTypesCondition.kt
@@ -1,40 +1,41 @@
 package us.timinc.mc.cobblemon.droploottables.condition
 
+import com.cobblemon.mod.common.api.types.ElementalType
 import com.mojang.serialization.Codec
 import com.mojang.serialization.MapCodec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
-import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class MoveTypesCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val moveTypes: List<ElementalType>,
+    val all: Boolean = false,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<MoveTypesCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
+                    .forGetter(MoveTypesCondition::targetPokemon),
+                ElementalType.BY_STRING_CODEC.listOf().fieldOf("move_types")
+                    .forGetter(MoveTypesCondition::moveTypes),
                 Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(MoveTypesCondition::all),
+            ).apply(instance, ::MoveTypesCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVE_TYPES_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        val pokemonMoveTypes = pokemon.moveSet.map { it.type }
+        return if (all) moveTypes.all(pokemonMoveTypes::contains) else moveTypes.any(pokemonMoveTypes::contains)
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/NatureCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/NatureCondition.kt
@@ -1,0 +1,44 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import kotlin.collections.map
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class NatureCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val natures: List<ResourceLocation>,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<NatureCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.listOf().fieldOf("natures")
+                    .forGetter { it.natures.map(ResourceLocation::toString) }
+            ).apply(instance) { pokemon, natures ->
+                NatureCondition(
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    natures.map(String::asIdentifierDefaultingNamespace)
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.NATURE_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        return natures.contains(pokemon.nature.name)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/NicknameCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/NicknameCondition.kt
@@ -6,35 +6,35 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class NicknameCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val name: String,
+    val caseInsensitive: Boolean = false,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<NicknameCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(NicknameCondition::targetPokemon),
+                Codec.STRING.fieldOf("name")
+                    .forGetter(NicknameCondition::name),
+                Codec.BOOL.fieldOf("case_insensitive").orElse(false)
+                    .forGetter(NicknameCondition::caseInsensitive)
+            ).apply(instance, ::NicknameCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.NICKNAME_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        val nickname = pokemon.nickname ?: return false
+        return if (caseInsensitive) nickname.string.equals(name, ignoreCase = true) else nickname.string == name
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/OriginalTrainerCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/OriginalTrainerCondition.kt
@@ -6,35 +6,31 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class OriginalTrainerCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val name: String,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<OriginalTrainerCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(OriginalTrainerCondition::targetPokemon),
+                Codec.STRING.fieldOf("name")
+                    .forGetter(OriginalTrainerCondition::name)
+            ).apply(instance, ::OriginalTrainerCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.ORIGINAL_TRAINER_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        return pokemon.originalTrainerName == name
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/PersistentDataCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/PersistentDataCondition.kt
@@ -6,35 +6,35 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class PersistentDataCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val key: String,
+    val value: String,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<PersistentDataCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(PersistentDataCondition::targetPokemon),
+                Codec.STRING.fieldOf("key")
+                    .forGetter(PersistentDataCondition::key),
+                Codec.STRING.fieldOf("value")
+                    .forGetter(PersistentDataCondition::value)
+            ).apply(instance, ::PersistentDataCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.PERSISTENT_DATA_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        val tagValue = pokemon.persistentData.get(key)?.asString ?: return false
+        return tagValue == value
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/PersistentDataRangeCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/PersistentDataRangeCondition.kt
@@ -1,0 +1,49 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.cobblemon.mod.common.util.math.FloatRange
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.toFloatRange
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class PersistentDataRangeCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val key: String,
+    val range: FloatRange,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<PersistentDataRangeCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.fieldOf("key").forGetter(PersistentDataRangeCondition::key),
+                Codec.STRING.fieldOf("range").forGetter { it.range.toString() }
+            ).apply(instance) { pokemon, key, range ->
+                PersistentDataRangeCondition(
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    key,
+                    toFloatRange(range)
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.PERSISTENT_DATA_RANGE_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val tagStringValue = pokemon.persistentData.get(key)?.asString ?: return false
+        val tagValue = tagStringValue.toFloatOrNull() ?: return false
+        return range.contains(tagValue)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/PropertiesCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/PropertiesCondition.kt
@@ -1,40 +1,38 @@
 package us.timinc.mc.cobblemon.droploottables.condition
 
+import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.mojang.serialization.Codec
 import com.mojang.serialization.MapCodec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class PropertiesCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val properties: String,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<PropertiesCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(PropertiesCondition::targetPokemon),
+                Codec.STRING.fieldOf("properties")
+                    .forGetter { it.properties }
+            ).apply(instance, ::PropertiesCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.PROPERTIES_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        val properties: PokemonProperties = PokemonProperties.parse(properties)
+        return properties.matches(pokemon)
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/ShinyCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/ShinyCondition.kt
@@ -6,35 +6,31 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class ShinyCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val value: Boolean = true,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<ShinyCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(ShinyCondition::targetPokemon),
+                Codec.BOOL.fieldOf("value").orElse(true)
+                    .forGetter(ShinyCondition::value)
+            ).apply(instance, ::ShinyCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.SHINY_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        return pokemon.shiny == value
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/StatusCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/StatusCondition.kt
@@ -1,0 +1,44 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class StatusCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val statuses: List<ResourceLocation>,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<StatusCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.listOf().fieldOf("status")
+                    .forGetter { it.statuses.map(ResourceLocation::toString) },
+            ).apply(instance) { pokemon, statuses ->
+                StatusCondition(
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    statuses.map(String::asIdentifierDefaultingNamespace)
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.STATUS_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        val pokemonStatus = pokemon.status ?: return false
+        return statuses.contains(pokemonStatus.status.name)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/TeraTypeCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/TeraTypeCondition.kt
@@ -1,0 +1,44 @@
+package us.timinc.mc.cobblemon.droploottables.condition
+
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.MOD_ID
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
+import kotlin.collections.map
+
+@Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
+class TeraTypeCondition(
+    val targetPokemon: ResourceLocation = FOCUS_POKEMON,
+    val types: List<ResourceLocation>,
+) : LootItemCondition {
+    companion object {
+        val CODEC: MapCodec<TeraTypeCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("target_pokemon", FOCUS_POKEMON.toString())
+                    .forGetter { it.targetPokemon.toString() },
+                Codec.STRING.listOf().fieldOf("type")
+                    .forGetter { it.types.map(ResourceLocation::toString) }
+            ).apply(instance) { pokemon, types ->
+                TeraTypeCondition(
+                    pokemon.asIdentifierDefaultingNamespace(MOD_ID),
+                    types.map(String::asIdentifierDefaultingNamespace)
+                )
+            }
+        }
+    }
+
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.TERA_TYPE_CONDITION
+
+    override fun test(ctx: LootContext): Boolean {
+        val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
+        return types.contains(pokemon.teraType.id)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/TradeableCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/condition/TradeableCondition.kt
@@ -6,35 +6,31 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootContext
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
-import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.DataKeys.LootParamKeys.FOCUS_POKEMON
+import us.timinc.mc.cobblemon.droploottables.paramextractor.PokemonParamExtractor
 
 @Deprecated ("Use the newly improved pokemon_matcher condition, it now accommodates this.")
-class MovesCondition (
+class TradeableCondition(
     val targetPokemon: ResourceLocation = FOCUS_POKEMON,
-    val moves: List<String>,
-    val all: Boolean = false
+    val value: Boolean = true,
 ) : LootItemCondition {
     companion object {
-        val CODEC: MapCodec<MovesCondition> = RecordCodecBuilder.mapCodec { instance ->
+        val CODEC: MapCodec<TradeableCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
                 ResourceLocation.CODEC.optionalFieldOf("target_pokemon", FOCUS_POKEMON)
-                    .forGetter(MovesCondition::targetPokemon),
-                Codec.STRING.listOf().fieldOf("moves")
-                    .forGetter(MovesCondition::moves),
-                Codec.BOOL.fieldOf("all").orElse(false)
-                    .forGetter(MovesCondition::all),
-            ).apply(instance, ::MovesCondition)
+                    .forGetter(TradeableCondition::targetPokemon),
+                Codec.BOOL.fieldOf("value").orElse(true)
+                    .forGetter(TradeableCondition::value)
+            ).apply(instance, ::TradeableCondition)
         }
     }
 
-    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.MOVES_CONDITION
+    override fun getType(): LootItemConditionType = DropLootTables.LootItemConditionTypes.TRADEABLE_CONDITION
 
     override fun test(ctx: LootContext): Boolean {
         val pokemon = PokemonParamExtractor.getFrom(ctx, targetPokemon) ?: return false
-        val pokemonMoveNames = pokemon.moveSet.map { it.name }
-        return if (all) moves.all(pokemonMoveNames::contains) else moves.any(pokemonMoveNames::contains)
+        return pokemon.tradeable == value
     }
 }


### PR DESCRIPTION
# Changes

Added remaining v1.6 deprecated conditions:

- ASPECTS
- DYNAMAX_LEVEL
- EGG_GROUP
- ELEMENTAL_TYPES
- EV
- FRIENDSHIP
- GENDER
- GMAX
- HELD_ITEM
- HIDDEN_ABILITY
- IV
- LABE
- LEVEL
- MOVE_TYPES
- NATURE
- NICKNAME
- ORIGINAL_TRAINER
- PERSISTENT_DATA
- PERSISTENT_DATA_RANGE
- PROPERTIES
- SHINY
- STATUS
- TERA_TYPE
- TRADEABLE